### PR TITLE
Add separate expired column and fix revocation logic

### DIFF
--- a/src/cert/listing.rs
+++ b/src/cert/listing.rs
@@ -84,13 +84,14 @@ impl CertificateListingService {
     ) -> Result<Vec<CertificateColumn>> {
         // Set default columns based on whether listing all mounts or specific mount
         let default_columns = if single_mount {
-            vec!["cn", "not_after", "revoked", "extended_key_usage"]
+            vec!["cn", "not_after", "revoked", "expired", "extended_key_usage"]
         } else {
             vec![
                 "pki_mount",
                 "cn",
                 "not_after",
                 "revoked",
+                "expired",
                 "extended_key_usage",
             ]
         };

--- a/src/storage/metadata.rs
+++ b/src/storage/metadata.rs
@@ -136,6 +136,13 @@ impl GetColumnValue for StorageCertificateMetadata {
             CertificateColumn::Issuer => "".to_string(), // Not available in storage metadata
             CertificateColumn::PkiMount => "".to_string(), // This comes from the parent struct
             CertificateColumn::Revoked => " ".to_string(), // Local storage doesn't track revocation
+            CertificateColumn::Expired => {
+                if self.is_expired() {
+                    "✗".to_string()
+                } else {
+                    " ".to_string()
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add new 'E' (Expired) column to distinguish expiration from revocation status  
- Fix revocation logic to properly check timestamp > 0 instead of just presence
- Update default columns to include both 'revoked' and 'expired' columns

## Test plan
- [x] Build passes without errors
- [x] Revoked certificates show ✗ in R column, space in E column  
- [x] Non-revoked certificates show space in both R and E columns
- [x] Column parsing supports 'expired' and 'e' aliases
- [x] Both Vault and storage certificate listings work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)